### PR TITLE
Fix fixPhpFilesArray Function because a new key full_path was added

### DIFF
--- a/FileBag.php
+++ b/FileBag.php
@@ -113,6 +113,8 @@ class FileBag extends ParameterBag
      */
     protected function fixPhpFilesArray($data)
     {
+        // Remove extra key added by PHP 8.1.
+        unset($data['full_path']);
         if (!\is_array($data)) {
             return $data;
         }


### PR DESCRIPTION
by PHP 8.1

PHP 8.1 fix for Bolt 3


https://github.com/symfony/symfony/issues/46146